### PR TITLE
Implement via keyword to influence route

### DIFF
--- a/src/Google.Maps.Test/Google.Maps.Test.csproj
+++ b/src/Google.Maps.Test/Google.Maps.Test.csproj
@@ -79,6 +79,7 @@
     <Compile Include="StaticMaps\StaticMapRequestTests.cs" />
     <Compile Include="StaticMaps\StaticMap_uribuilding_Tests.cs" />
     <Compile Include="ValueTextComparer.cs" />
+    <Compile Include="ViaLatLngTests.cs" />
     <EmbeddedResource Include="Geocoding\json_queries\address=11+Wall+Street+New+York+NY+10005.json" />
     <EmbeddedResource Include="Geocoding\json_queries\address=1600+Amphitheatre+Parkway+Mountain+View+CA.json" />
     <EmbeddedResource Include="Geocoding\json_queries\latlng=40.714233,-73.961291.json" />

--- a/src/Google.Maps.Test/ViaLatLngTests.cs
+++ b/src/Google.Maps.Test/ViaLatLngTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Google.Maps;
+
+namespace Google.Maps.Test
+{
+    [TestFixture]
+    public class ViaLatLngTests
+    {
+        [Test]
+        public void ToString_default_format()
+        {
+            ViaLatLng ViaLatLng = new ViaLatLng(-35.3353m, 95.4454m);
+
+            string expected = "via:-35.335300,95.445400";
+            string actual = ViaLatLng.ToString();
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        [TestCase(-35.3353d, 95.4454d, "via:-35.3353,95.4454")]
+        [TestCase(40.7142330d, -73.9612910d, "via:40.714233,-73.961291")]
+        public void GetAsUrlEncoded(double lat, double lng, string expected)
+        {
+            ViaLatLng ViaLatLng = new ViaLatLng(lat, lng);
+
+            //string expected = "via:-35.335300,95.445400";
+            string actual = ViaLatLng.GetAsUrlParameter();
+
+            //note, if this test starts failing, it may be because the 'comma' is being (in some circles' opinion) "properly" url encoded to %2c
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Parse_test()
+        {
+            string value = "40.714224,-73.961452";
+
+            ViaLatLng expected = new ViaLatLng(40.714224m, -73.961452m);
+            ViaLatLng actual = ViaLatLng.Parse(value);
+
+            Assert.AreEqual(expected.Latitude, actual.Latitude);
+            Assert.AreEqual(expected.Longitude, actual.Longitude);
+        }
+
+        [Test]
+        public void ToString_using_invariant_culture_settings()
+        {
+            ViaLatLng test = new ViaLatLng(40.714224m, -73.961452m);
+
+            System.Globalization.CultureInfo savedCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
+
+            try
+            {
+                //change the thread culture
+                System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.GetCultureInfo("nl-BE");//belgium uses different numbering
+
+                string expected = "via:40.714224,-73.961452";
+                string actual = test.ToString();
+
+                Assert.AreEqual(expected, actual);
+            }
+            finally
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = savedCulture;
+            }
+        }
+
+        [Test]
+        [TestCase(30.1d, 60.2d)]
+        public void Equals(double lat, double lng)
+        {
+            ViaLatLng ViaLatLng1 = new ViaLatLng(lat, lng);
+            ViaLatLng ViaLatLng2 = new ViaLatLng(lat, lng);
+
+            Assert.IsTrue(ViaLatLng1.Equals(ViaLatLng2), "Equals fails.");
+        }
+
+        [Test]
+        [TestCase(40.2d, 70.3d)]
+        public void NotEquals(double lat, double lng)
+        {
+            ViaLatLng ViaLatLng1 = new ViaLatLng(lat, lng);
+            ViaLatLng ViaLatLng2 = new ViaLatLng(0d, lng);
+
+            Assert.IsFalse(ViaLatLng1.Equals(ViaLatLng2));
+
+            ViaLatLng ViaLatLng3 = new ViaLatLng(lat, 0d);
+            Assert.IsFalse(ViaLatLng1.Equals(ViaLatLng3));
+
+            ViaLatLng ViaLatLng4 = new ViaLatLng(0d, 0d);
+            Assert.IsFalse(ViaLatLng1.Equals(ViaLatLng4));
+        }
+
+    }
+}

--- a/src/Google.Maps/Google.Maps.csproj
+++ b/src/Google.Maps/Google.Maps.csproj
@@ -129,6 +129,7 @@
     <Compile Include="StaticMaps\StaticMapService.cs" />
     <Compile Include="TravelMode.cs" />
     <Compile Include="Units.cs" />
+    <Compile Include="ViaLatLng.cs" />
     <Compile Include="ViewportComparer.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/Google.Maps/ViaLatLng.cs
+++ b/src/Google.Maps/ViaLatLng.cs
@@ -1,0 +1,176 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Newtonsoft.Json;
+using System;
+using System.Globalization;
+
+namespace Google.Maps
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    [Serializable]
+    public class ViaLatLng : Location, IEquatable<ViaLatLng>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ViaLatLng" /> class.
+        /// </summary>
+        public ViaLatLng()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ViaLatLng" /> class with the given latitude and longitude coordinates.
+        /// </summary>
+        /// <param name="latitude">Latitude coordinates.</param>
+        /// <param name="longitude">Longitude coordinates.</param>
+        public ViaLatLng(decimal latitude, decimal longitude)
+        {
+            this._latitude = Convert.ToDouble(latitude);
+            this._longitude = Convert.ToDouble(longitude);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ViaLatLng" /> class with the given latitude and longitude coordinates.
+        /// </summary>
+        /// <param name="latitude">Latitude coordinates.</param>
+        /// <param name="longitude">Longitude coordinates.</param>
+        public ViaLatLng(double latitude, double longitude)
+        {
+            this._latitude = latitude;
+            this._longitude = longitude;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ViaLatLng" /> class with the given latitude and longitude coordinates.
+        /// </summary>
+        /// <param name="latitude">Latitude coordinates.</param>
+        /// <param name="longitude">Longitude coordinates.</param>
+        public ViaLatLng(float latitude, float longitude)
+        {
+            this._latitude = Convert.ToDouble(latitude);
+            this._longitude = Convert.ToDouble(longitude);
+        }
+
+        private double _latitude;
+        private double _longitude;
+
+        /// <summary>
+        /// Gets the latitude coordinate.
+        /// </summary>
+        [JsonProperty("lat")]
+        public double Latitude
+        {
+            get { return _latitude; }
+        }
+
+        /// <summary>
+        /// Gets the longitude coordinate.
+        /// </summary>
+        [JsonProperty("lng")]
+        public double Longitude
+        {
+            get { return _longitude; }
+        }
+
+        /// <summary>
+        /// Gets the string representation of the latitude and longitude coordinates. Default format is "N6" for 6 decimal precision.
+        /// </summary>
+        /// <returns>Latitude and longitude coordinates.</returns>
+        public override string ToString()
+        {
+            return this.ToString("N6");
+        }
+
+        /// <summary>
+        /// Gets the string representation of the latitude and longitude coordinates. The format is applies to a System.Double, so any format applicable for System.Double will work.
+        /// </summary>
+        /// <param name="format"></param>
+        /// <returns></returns>
+        public string ToString(string format)
+        {
+            System.Text.StringBuilder sb = new System.Text.StringBuilder(50); //default to 50 in the internal array.
+            sb.Append("via:");
+            sb.Append(this.Latitude.ToString(format, System.Globalization.CultureInfo.InvariantCulture));
+            sb.Append(",");
+            sb.Append(this.Longitude.ToString(format, System.Globalization.CultureInfo.InvariantCulture));
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Gets the current instance as a URL encoded value.
+        /// </summary>
+        /// <returns></returns>
+        public override string GetAsUrlParameter()
+        {
+            //we're not returning crazy characters so just return the string.  
+            //prevents the comma from being converted to %2c, expanding the single character to three characters.
+            return this.ToString("R");
+        }
+
+        #region Parse
+
+        /// <summary>
+        /// Parses a ViaLatLng from a set of latitude/longitude coordinates
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static ViaLatLng Parse(string value)
+        {
+            if (value == null) throw new ArgumentNullException("value");
+
+            try
+            {
+                string[] parts = value.Split(',');
+
+                if (parts.Length != 2) throw new FormatException("Missing data for points.");
+
+                double latitude = double.Parse(parts[0].Trim(), CultureInfo.InvariantCulture);
+                double longitude = double.Parse(parts[1].Trim(), CultureInfo.InvariantCulture);
+
+                ViaLatLng vialatlng = new ViaLatLng(latitude, longitude);
+
+                return vialatlng;
+            }
+            catch (Exception ex)
+            {
+                throw new FormatException("Failed to parse ViaLatLng.", ex);
+            }
+        }
+        #endregion
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ViaLatLng);
+        }
+
+        public bool Equals(ViaLatLng other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (other.Latitude == this.Latitude && other.Longitude == this.Longitude)
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
You can use waypoints to influence your route without adding a stopover by prefixing the waypoint with "via:". Waypoints prefixed with via: will not add an additional leg to the route.