### PR TITLE
Escape the query string for TextSearchRequest.

### DIFF
--- a/src/Google.Maps/Places/TextSearchRequest.cs
+++ b/src/Google.Maps/Places/TextSearchRequest.cs
@@ -40,7 +40,7 @@ namespace Google.Maps.Places
 			ValidateRequest();
 			var qsb = new Internal.QueryStringBuilder();
 
-			qsb.Append("query", Query.ToLowerInvariant())
+			qsb.Append("query", Uri.EscapeDataString(Query.ToLowerInvariant()))
 			   .Append("sensor", (Sensor.Value.ToString().ToLowerInvariant()));
 
 			if (Location != null)


### PR DESCRIPTION
Previously the query string was not escaped, leading to incorrect results.
For example, any query containing '&' would fail.

I have test cases for this (if you want them), to verify the `ToUri()` method, however they don't work since `ToUri()` is internal, and using the `InternalsVisibleTo` trick requires the Test assembly to be signed, which it isn't currently.