### PR TITLE
Add GeocodedWaypoints to DirectionResponse class

### DIFF
--- a/src/Google.Maps.Test/QuickExamplesTests.cs
+++ b/src/Google.Maps.Test/QuickExamplesTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-
+using Google.Maps.Direction;
 using NUnit.Framework;
 using Google.Maps.Geocoding;
 using Google.Maps.StaticMaps;
@@ -50,6 +50,21 @@ namespace Google.Maps.Test
 
 			Assert.Pass();
 		}
+
+	    [Test]
+	    public void PartialMatchTest()
+	    {
+            // invalid address results in partial match
+	        var request = new DirectionRequest
+	        {
+                Sensor = false,
+	            Origin = new Location("410 Beeeeeechwood Rd, NJ 07450"),
+	            Destination = new Location("204 Powell Ave, CA 94523")
+	        };
+	        var response = new DirectionService().GetResponse(request);
+
+            Assert.True(response.GeocodedWaypoints.Any(wp => wp.PartialMatch));
+	    }
 
 	}
 }

--- a/src/Google.Maps/Direction/DirectionResponse.cs
+++ b/src/Google.Maps/Direction/DirectionResponse.cs
@@ -9,10 +9,19 @@ namespace Google.Maps.Direction
 	[JsonObject(MemberSerialization.OptIn)]
 	public class DirectionResponse
 	{
+        [JsonProperty("geocoded_waypoints")]
+        public GeocodedWaypoint[] GeocodedWaypoints { get; set; }
+
 		[JsonProperty("status")]
 		public ServiceResponseStatus Status { get; set; }
 
 		[JsonProperty("routes")]
 		public DirectionRoute[] Routes { get; set; }
 	}
+
+    public class GeocodedWaypoint
+    {
+        [JsonProperty("partial_match")]
+        public bool PartialMatch { get; set; }
+    }
 }


### PR DESCRIPTION
This helps determining if either origin or destination addresses were invalid when making a DirectionRequest. With invalid address the response can still be valid, but the directions are incomplete.

DirectionService's response Json contains "geocoded_waypoints"-list and the items contain "partial_match"-boolean. An invalid address results to "partial_match" being true.