### PR TITLE
More scenarios support

### DIFF
--- a/src/Google.Maps/ComponentFilter.cs
+++ b/src/Google.Maps/ComponentFilter.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Google.Maps
+{
+    /// <summary>
+    /// In a geocoding response, the Google Maps Geocoding API can return address results restricted to a specific area.
+    /// The restriction is specified using the components filter. A filter consists of a list of component:value pairs separated
+    /// by a pipe (|). Only the results that match all the filters will be returned. Filter values support the same methods of
+    /// spelling correction and partial matching as other geocoding requests. If a geocoding result is a partial match for a
+    /// component filter it will contain a partial_match field in the response.
+    /// </summary>
+    public class ComponentFilter
+    {
+        private Dictionary<string, string> parameters = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Matches long or short name of a route. 
+        /// </summary>
+        public string Route
+        {
+            get
+            {
+                return TryGetParameter("route");
+            }
+            set
+            {
+                parameters["route"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Matches against both locality and sublocality types.
+        /// </summary>
+        public string Locality
+        {
+            get
+            {
+                return TryGetParameter("locality");
+            }
+            set
+            {
+                parameters["locality"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Matches all the administrative_area levels.
+        /// </summary>
+        public string AdministrativeArea
+        {
+            get
+            {
+                return TryGetParameter("administrative_area");
+            }
+            set
+            {
+                parameters["administrative_area"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Matches postal_code and postal_code_prefix.
+        /// </summary>
+        public string PostalCode
+        {
+            get
+            {
+                return TryGetParameter("postal_code");
+            }
+            set
+            {
+                parameters["postal_code"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Matches a country name or a two letter ISO 3166-1 country code.
+        /// </summary>
+        public string Country
+        {
+            get
+            {
+                return TryGetParameter("country");
+            }
+            set
+            {
+                parameters["country"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Converts filter to Url string.
+        /// </summary>
+        internal string ToUrlParameters()
+        {
+            var parametersList = parameters.Where(p => !(string.IsNullOrEmpty(p.Value) || p.Value.Trim().Length == 0)).Select(p => p.Key + ":" + p.Value);
+            var parametersListFlatten = string.Join("|", parametersList.ToArray());
+
+            return Uri.EscapeDataString(parametersListFlatten);
+        }
+
+        private string TryGetParameter(string key)
+        {
+            string route = null;
+            parameters.TryGetValue(key, out route);
+
+            return route;
+        }
+
+        /// <summary>
+		/// implicitly converts a System.String to Google.Maps.ComponentFilter
+		/// </summary>
+		/// <param name="components">A filter consists of a list of component:value pairs separated by a pipe (|). For exemple: \"country:ES|locality:Santa Cruz de Tenerife\".</param>
+		/// <returns></returns>
+		public static implicit operator ComponentFilter(string components)
+        {
+            if (string.IsNullOrEmpty(components) || components.Trim().Length == 0)
+            {
+                return null;
+            }
+
+            var componentFilter = new ComponentFilter();
+            var filters = components.Split('|');
+
+            foreach (var filter in filters)
+            {
+                var filterSplitted = filter.Split(':');
+
+                if (filterSplitted.Length != 2)
+                {
+                    throw new ArgumentException("One of the filters is not well formated. Make sure that each filter is written \"component:value\" and are separated by \"|\". For exemple, \"country:ES|locality:Santa Cruz de Tenerife\"", "components");
+                }
+
+                var component = filterSplitted[0];
+                var value = filterSplitted[1];
+
+                switch (component.ToLowerInvariant())
+                {
+                    case "route":
+                        componentFilter.Route = value;
+                        break;
+                    case "locality":
+                        componentFilter.Locality = value;
+                        break;
+                    case "administrative_area":
+                        componentFilter.AdministrativeArea = value;
+                        break;
+                    case "postal_code":
+                        componentFilter.PostalCode = value;
+                        break;
+                    case "country":
+                        componentFilter.Country = value;
+                        break;
+                    default:
+                        throw new ArgumentException("The value '" + component + "' is not a valid component.", "components");
+                }
+            }
+
+            return componentFilter;
+        }
+    }
+}

--- a/src/Google.Maps/Geocoding/GeocodingRequest.cs
+++ b/src/Google.Maps/Geocoding/GeocodingRequest.cs
@@ -33,23 +33,23 @@ namespace Google.Maps.Geocoding
 		/// <remarks>Required if latlng not present.</remarks>
 		public Location Address { get; set; }
 
-		/// <summary>
-		/// Undocumented address component filters.
-		/// Only geocoding results matching the component filters will be returned.
-		/// </summary>
-		/// <remarks>IE: country:uk|locality:stathern</remarks>
-		public string Components { get; set; }
+        /// <summary>
+        /// Undocumented address component filters.
+        /// Only geocoding results matching the component filters will be returned.
+        /// </summary>
+        /// <remarks>IE: country:uk|locality:stathern</remarks>
+        public ComponentFilter Components { get; set; }
 
-		/// <summary>
-		/// The bounding box of the viewport within which to bias geocode
-		/// results more prominently.
-		/// </summary>
-		/// <remarks>
-		/// Optional. This parameter will only influence, not fully restrict, results
-		/// from the geocoder.
-		/// </remarks>
-		/// <see cref="http://code.google.com/apis/maps/documentation/geocoding/#Viewports"/>
-		public Viewport Bounds { get; set; }
+        /// <summary>
+        /// The bounding box of the viewport within which to bias geocode
+        /// results more prominently.
+        /// </summary>
+        /// <remarks>
+        /// Optional. This parameter will only influence, not fully restrict, results
+        /// from the geocoder.
+        /// </remarks>
+        /// <see cref="http://code.google.com/apis/maps/documentation/geocoding/#Viewports"/>
+        public Viewport Bounds { get; set; }
 
 		/// <summary>
 		/// The region code, specified as a ccTLD ("top-level domain")
@@ -97,7 +97,7 @@ namespace Google.Maps.Geocoding
             }
 
             qsb.Append("bounds", GetBoundsStr())
-				.Append("components", HttpUtility.UrlEncode(Components))
+				.Append("components", Components != null ? Components.ToUrlParameters() : "")
 				.Append("region", Region)
 				.Append("language", Language)
 				.Append("sensor", (Sensor.Value.ToString().ToLowerInvariant()));

--- a/src/Google.Maps/Geocoding/GeocodingRequest.cs
+++ b/src/Google.Maps/Geocoding/GeocodingRequest.cs
@@ -81,20 +81,22 @@ namespace Google.Maps.Geocoding
 		internal Uri ToUri()
 		{
 			EnsureSensor();
-			if (Address == null) throw new InvalidOperationException("Address property is not set.");
 
 			var qsb = new Internal.QueryStringBuilder();
 
-			if(this.Address.GetType() == typeof(LatLng))
-			{
-				qsb.Append("latlng", Address.GetAsUrlParameter());
-			}
-			else
-			{
-				qsb.Append("address", Address.GetAsUrlParameter());
-			}
-				
-			qsb.Append("bounds", GetBoundsStr())
+            if (Address != null)
+            {
+                if (this.Address.GetType() == typeof(LatLng))
+                {
+                    qsb.Append("latlng", Address.GetAsUrlParameter());
+                }
+                else
+                {
+                    qsb.Append("address", Address.GetAsUrlParameter());
+                }
+            }
+
+            qsb.Append("bounds", GetBoundsStr())
 				.Append("components", HttpUtility.UrlEncode(Components))
 				.Append("region", Region)
 				.Append("language", Language)

--- a/src/Google.Maps/Geocoding/Result.cs
+++ b/src/Google.Maps/Geocoding/Result.cs
@@ -57,5 +57,21 @@ namespace Google.Maps.Geocoding
 
 		[JsonProperty("geometry")]
 		public Geometry Geometry { get; set; }
-	}
+
+        /// <summary>
+        /// Indicates that the geocoder did not return an exact match for the
+        /// original request, though it was able to match part of the requested address.
+        /// </summary>
+        [JsonProperty("partial_match")]
+        public bool PartialMatch { get; set; }
+
+        /// <summary>
+        /// Is a unique identifier that can be used with other Google APIs.For example, you can use
+        /// the place_id in a <see href="https://developers.google.com/places/web-service/details">Google Places API</see>
+        /// request to get details of a local business, such as phone number, opening hours, user reviews, and more. See
+        /// the <see href="https://developers.google.com/places/place-id">place ID overview</see>.
+        /// </summary>
+        [JsonProperty("place_id")]
+        public string PlaceId { get; set; }
+    }
 }

--- a/src/Google.Maps/Google.Maps.csproj
+++ b/src/Google.Maps/Google.Maps.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Avoid.cs" />
     <Compile Include="AvoidHelper.cs" />
     <Compile Include="BaseSigningService.cs" />
+    <Compile Include="ComponentFilter.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Direction\DirectionLeg.cs" />
     <Compile Include="Direction\DirectionRequest.cs" />

--- a/src/Google.Maps/Shared/AddressType.cs
+++ b/src/Google.Maps/Shared/AddressType.cs
@@ -17,147 +17,186 @@
 
 namespace Google.Maps.Shared
 {
-	public enum AddressType
-	{
-		Unknown = 0,
+    public enum AddressType
+    {
+        Unknown = 0,
 
-		/// <summary>
-		/// Indicates a precise street address.
-		/// </summary>
-		StreetAddress = 1,
+        /// <summary>
+        /// Indicates a precise street address.
+        /// </summary>
+        StreetAddress = 1,
 
-		/// <summary>
-		/// Indicates a named route (such as "US 101").
-		/// </summary>
-		Route = 2,
+        /// <summary>
+        /// Indicates a named route (such as "US 101").
+        /// </summary>
+        Route = 2,
 
-		/// <summary>
-		/// Indicates a major intersection, usually of two major roads.
-		/// </summary>
-		Intersection = 3,
+        /// <summary>
+        /// Indicates a major intersection, usually of two major roads.
+        /// </summary>
+        Intersection = 3,
 
-		/// <summary>
-		/// Indicates a political entity. Usually, this type indicates a polygon of
-		/// some civil administration.
-		/// </summary>
-		Political = 4,
+        /// <summary>
+        /// Indicates a political entity. Usually, this type indicates a polygon of
+        /// some civil administration.
+        /// </summary>
+        Political = 4,
 
-		/// <summary>
-		/// Indicates the national political entity, and is typically the highest
-		/// order type returned by the Geocoder.
-		/// </summary>
-		Country = 5,
+        /// <summary>
+        /// Indicates the national political entity, and is typically the highest
+        /// order type returned by the Geocoder.
+        /// </summary>
+        Country = 5,
 
-		/// <summary>
-		/// Indicates a first-order civil entity below the country level. Within the
-		/// United States, these administrative levels are states. Not all nations
-		/// exhibit these administrative levels.
-		/// </summary>
-		AdministrativeAreaLevel1 = 6,
+        /// <summary>
+        /// Indicates a first-order civil entity below the country level. Within the
+        /// United States, these administrative levels are states. Not all nations
+        /// exhibit these administrative levels.
+        /// </summary>
+        AdministrativeAreaLevel1 = 6,
 
-		/// <summary>
-		/// Indicates a second-order civil entity below the country level. Within the
-		/// United States, these administrative levels are counties. Not all nations
-		/// exhibit these administrative levels.
-		/// </summary>
-		AdministrativeAreaLevel2 = 7,
+        /// <summary>
+        /// Indicates a second-order civil entity below the country level. Within the
+        /// United States, these administrative levels are counties. Not all nations
+        /// exhibit these administrative levels.
+        /// </summary>
+        AdministrativeAreaLevel2 = 7,
 
-		/// <summary>
-		/// Indicates a third-order civil entity below the country level. This type
+        /// <summary>
+        /// Indicates a third-order civil entity below the country level. This type
+        /// indicates a minor civil division. Not all nations exhibit these
+        /// administrative levels.
+        /// </summary>
+        AdministrativeAreaLevel3 = 8,
+
+        /// <summary>
+		/// Indicates a fourth-order civil entity below the country level. This type
 		/// indicates a minor civil division. Not all nations exhibit these
 		/// administrative levels.
 		/// </summary>
-		AdministrativeAreaLevel3 = 8,
+		AdministrativeAreaLevel4 = 31,
 
-		/// <summary>
-		/// Indicates a commonly-used alternative name for the entity.
+        /// <summary>
+		/// Indicates a fifth-order civil entity below the country level. This type
+		/// indicates a minor civil division. Not all nations exhibit these
+		/// administrative levels.
 		/// </summary>
-		ColloquialArea = 9,
+		AdministrativeAreaLevel5 = 32,
 
-		/// <summary>
-		/// Indicates an incorporated city or town political entity.
-		/// </summary>
-		Locality = 10,
+        /// <summary>
+        /// Indicates a commonly-used alternative name for the entity.
+        /// </summary>
+        ColloquialArea = 9,
 
-		/// <summary>
+        /// <summary>
+        /// Indicates an incorporated city or town political entity.
+        /// </summary>
+        Locality = 10,
+
+        /// <summary>
+        /// Indicates an first-order civil entity below a locality.
+        /// </summary>
+        Sublocality = 11,
+
+        /// <summary>
 		/// Indicates an first-order civil entity below a locality.
 		/// </summary>
-		Sublocality = 11,
+        SublocalityLevel1 = 26,
 
-		/// <summary>
-		/// Indicates a named neighborhood.
+        /// <summary>
+		/// Indicates an second-order civil entity below a locality.
 		/// </summary>
-		Neighborhood = 12,
+        SublocalityLevel2 = 27,
 
-		/// <summary>
-		/// Indicates a named location, usually a building or collection of
-		/// buildings with a common name.
+        /// <summary>
+		/// Indicates an third-order civil entity below a locality.
 		/// </summary>
-		Premise = 13,
+        SublocalityLevel3 = 28,
 
-		/// <summary>
-		/// Indicates a first-order entity below a named location, usually a
-		/// singular building within a collection of buildings with a common
-		/// name.
+        /// <summary>
+		/// Indicates an fourth-order civil entity below a locality.
 		/// </summary>
-		Subpremise = 14,
+        SublocalityLevel4 = 29,
 
-		/// <summary>
-		/// Indicates a postal code as used to address postal mail within the
-		/// country.
+        /// <summary>
+		/// Indicates an fifth-order civil entity below a locality.
 		/// </summary>
-		PostalCode = 15,
+        SublocalityLevel5 = 30,
 
-		/// <summary>
-		/// Indicates a prominent natural feature.
-		/// </summary>
-		NaturalFeature = 16,
+        /// <summary>
+        /// Indicates a named neighborhood.
+        /// </summary>
+        Neighborhood = 12,
 
-		/// <summary>
-		/// Indicates an airport.
-		/// </summary>
-		Airport = 17,
+        /// <summary>
+        /// Indicates a named location, usually a building or collection of
+        /// buildings with a common name.
+        /// </summary>
+        Premise = 13,
 
-		/// <summary>
-		/// Indicates a named park.
-		/// </summary>
-		Park = 18,
+        /// <summary>
+        /// Indicates a first-order entity below a named location, usually a
+        /// singular building within a collection of buildings with a common
+        /// name.
+        /// </summary>
+        Subpremise = 14,
 
-		/// <summary>
-		/// Indicates a named point of interest. Typically, these "POI"s are
-		/// prominent local entities that don't easily fit in another category
-		/// such as "Empire State Building" or "Statue of Liberty."
-		/// </summary>
-		PointOfInterest = 19,
+        /// <summary>
+        /// Indicates a postal code as used to address postal mail within the
+        /// country.
+        /// </summary>
+        PostalCode = 15,
 
-		/// <summary>
-		/// Indicates a specific postal box.
-		/// </summary>
-		PostBox = 20,
+        /// <summary>
+        /// Indicates a prominent natural feature.
+        /// </summary>
+        NaturalFeature = 16,
 
-		/// <summary>
-		/// Indicates the precise street number.
-		/// </summary>
-		StreetNumber = 21,
+        /// <summary>
+        /// Indicates an airport.
+        /// </summary>
+        Airport = 17,
 
-		/// <summary>
-		/// Indicates the floor of a building address.
-		/// </summary>
-		Floor = 22,
+        /// <summary>
+        /// Indicates a named park.
+        /// </summary>
+        Park = 18,
 
-		/// <summary>
-		/// Indicates the room of a building address.
-		/// </summary>
-		Room = 23,
+        /// <summary>
+        /// Indicates a named point of interest. Typically, these "POI"s are
+        /// prominent local entities that don't easily fit in another category
+        /// such as "Empire State Building" or "Statue of Liberty."
+        /// </summary>
+        PointOfInterest = 19,
 
-		/// <summary>
-		/// (Not documented) Indicates the Postal Town (nearest large town / city for UK addresses)
-		/// </summary>
-		PostalTown = 24,
+        /// <summary>
+        /// Indicates a specific postal box.
+        /// </summary>
+        PostBox = 20,
 
-		/// <summary>
-		/// (Not documented) First half of postcode for the UK
-		/// </summary>
-		PostalCodePrefix = 25
-	}
+        /// <summary>
+        /// Indicates the precise street number.
+        /// </summary>
+        StreetNumber = 21,
+
+        /// <summary>
+        /// Indicates the floor of a building address.
+        /// </summary>
+        Floor = 22,
+
+        /// <summary>
+        /// Indicates the room of a building address.
+        /// </summary>
+        Room = 23,
+
+        /// <summary>
+        /// (Not documented) Indicates the Postal Town (nearest large town / city for UK addresses)
+        /// </summary>
+        PostalTown = 24,
+
+        /// <summary>
+        /// (Not documented) First half of postcode for the UK
+        /// </summary>
+        PostalCodePrefix = 25
+    }
 }


### PR DESCRIPTION
I added the possibility to make a request without the address property. Google can accept request with it and it's usefull if you only want to search for a postal code by using the component filter.

Also, i've added a fully typed ComponentFilter object. I think it can be easier to use it than using the feature by composing the string by yourself. But you still have the choice.