### PR TITLE
Added Resolution property to ElevationResult

### DIFF
--- a/src/Google.Maps/Elevation/ElevationResult.cs
+++ b/src/Google.Maps/Elevation/ElevationResult.cs
@@ -27,5 +27,8 @@ namespace Google.Maps.Elevation
 
 		[JsonProperty("elevation")]
 		public decimal Elevation { get; set; }
+
+		[JsonProperty("resolution")]
+		public decimal Resolution { get; set; }
 	}
 }


### PR DESCRIPTION
According to official API documentation there is an additional property in the elevation response called resolution. See https://developers.google.com/maps/documentation/elevation/intro#ElevationResponses

This is quite interesting to evaluate the quality of the elevation data and should be available to the user.