### PR TITLE
Refactor request url generation and testing

### DIFF
--- a/src/Google.Maps.Test/Direction/DirectionRequestTests.cs
+++ b/src/Google.Maps.Test/Direction/DirectionRequestTests.cs
@@ -13,45 +13,6 @@ namespace Google.Maps.Test
 	[TestFixture]
 	public class DirectionRequestTests
 	{
-
-		#region DirectionRequestAccessor
-		public class DirectionRequestAccessor : DirectionRequest
-		{
-			private static Type S_instanceType;
-			private static MethodInfo _ToUri;
-
-			static DirectionRequestAccessor()
-			{
-				S_instanceType = typeof(DirectionRequest);
-
-				try { _ToUri = S_instanceType.GetMethod("ToUri", BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { }, new ParameterModifier[] { }); }
-				catch { }
-				finally { Ensure(_ToUri, "ToUri"); }
-			}
-
-			private static void Ensure(MethodInfo methodInfo, string methodName)
-			{
-				if(methodInfo == null) Assert.Fail("Method '{0}' on type '{1}' was not found, and the accessor will fail.", methodName, S_instanceType);
-			}
-
-			#region Protected/Private interface
-			public Uri ToUri()
-			{
-				try
-				{
-					return (Uri)_ToUri.Invoke(this, new object[] { });
-				}
-				catch(TargetInvocationException ex)
-				{
-					throw ex.InnerException;
-				}
-			}
-			#endregion
-
-
-		}
-		#endregion
-
 		#region helpers
 
 		NameValueCollection ParseQueryString(Uri uri)
@@ -119,7 +80,7 @@ namespace Google.Maps.Test
 		
 		public void GetUrl_sensor_not_set_should_throw_error()
 		{
-			var req = new DirectionRequestAccessor();
+			var req = new DirectionRequest();
 
 			//act
 			//assert
@@ -132,7 +93,7 @@ namespace Google.Maps.Test
 		[Test]
 		public void GetUrl_no_Origin_set()
 		{
-			var req = new DirectionRequestAccessor();
+			var req = new DirectionRequest();
 			//req.Origin = nothing basically;
 
 			//act
@@ -147,7 +108,7 @@ namespace Google.Maps.Test
 		[ExpectedException(typeof(InvalidOperationException))]
 		public void GetUrl_no_Destination_set()
 		{
-			var req = new DirectionRequestAccessor();
+			var req = new DirectionRequest();
 			//req.Origin = nothing basically;
 
 			//act
@@ -164,7 +125,7 @@ namespace Google.Maps.Test
 			//arrange
 			var expected = ParseQueryString("json?origin=New York, NY&destination=Albany, NY&sensor=false");
 
-			var req = new DirectionRequestAccessor();
+			var req = new DirectionRequest();
 			req.Sensor = false;
 			req.Origin = "New York, NY";
 			req.Destination = "Albany, NY";
@@ -187,7 +148,7 @@ namespace Google.Maps.Test
 				{ "sensor", "false" }
 			};
 
-			var req = new DirectionRequestAccessor();
+			var req = new DirectionRequest();
 			req.Sensor = false;
 			req.Origin = new LatLng(30.2, 40.3);
 			req.Destination = new LatLng(50.5, 60.6);
@@ -206,7 +167,7 @@ namespace Google.Maps.Test
 			//arrange
 			var expected = ParseQueryString("json?origin=NY&destination=FL&waypoints=NC&sensor=false");
 
-			var req = new DirectionRequestAccessor();
+			var req = new DirectionRequest();
 			req.Sensor = false;
 			req.Origin = "NY";
 			req.Destination = "FL";
@@ -228,7 +189,7 @@ namespace Google.Maps.Test
 			//arrange
 			var expected = ParseQueryString("json?origin=NY&destination=Orlando,FL&waypoints=28.452694,-80.979195&sensor=false");
 
-			var req = new DirectionRequestAccessor();
+			var req = new DirectionRequest();
 			req.Sensor = false;
 			req.Origin = "NY";
 			req.Destination = "Orlando,FL";
@@ -249,7 +210,7 @@ namespace Google.Maps.Test
 			//arrange
 			var expected = ParseQueryString("json?origin=NY&destination=Orlando,FL&waypoints=NJ|28.452694,-80.979195|Sarasota,FL&sensor=false");
 
-			var req = new DirectionRequestAccessor();
+			var req = new DirectionRequest();
 			req.Sensor = false;
 			req.Origin = "NY";
 			req.Destination = "Orlando,FL";

--- a/src/Google.Maps.Test/Elevation/ElevationRequestTests.cs
+++ b/src/Google.Maps.Test/Elevation/ElevationRequestTests.cs
@@ -12,45 +12,11 @@ namespace Google.Maps.Test.Elevation
 	[TestFixture]
 	class ElevationRequestTests
 	{
-
-		public class ElevationRequestAccessor : ElevationRequest
-		{
-			#region Accessor goo
-			private static Type S_instanceType = typeof(ElevationRequest);
-			private static MethodInfo S_ToUriMethod;
-
-			static ElevationRequestAccessor()
-			{
-				try { S_ToUriMethod = S_instanceType.GetMethod("ToUri", BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { }, new ParameterModifier[] { }); }
-				catch { }
-				finally { Ensure(S_ToUriMethod, "ToUri"); }
-			}
-
-			private static void Ensure(MethodInfo methodInfo, string methodName)
-			{
-				if(methodInfo == null) Assert.Fail("Method '{0}' on type '{1}' was not found, and the accessor will fail.", methodName, S_instanceType);
-			}
-			#endregion
-
-			public Uri ToUri()
-			{
-				try
-				{
-					return (Uri)S_ToUriMethod.Invoke(this, new object[] { });
-				}
-				catch(TargetInvocationException ex)
-				{
-					throw ex.InnerException;
-				}
-			}
-
-		}
-
 		[Test]
 		[ExpectedException(typeof(InvalidOperationException))]
 		public void Sensor_not_set_throws()
 		{
-			var req = new ElevationRequestAccessor();
+			var req = new ElevationRequest();
 
 			Uri url = req.ToUri();
 
@@ -60,7 +26,7 @@ namespace Google.Maps.Test.Elevation
 		[Test]
 		public void GetUrl_one_location()
 		{
-			var req = new ElevationRequestAccessor();
+			var req = new ElevationRequest();
 			req.Sensor = false;
 			req.Locations.Add(new LatLng(40.714728, -73.998672));
 

--- a/src/Google.Maps.Test/Geocoding/GeocodingRequestTests.cs
+++ b/src/Google.Maps.Test/Geocoding/GeocodingRequestTests.cs
@@ -11,58 +11,6 @@ namespace Google.Maps.Test
 	[TestFixture]
 	public class GeocodingRequestTests
 	{
-
-
-		public class GeocodingRequestAccessor
-		{
-			private GeocodingRequest _instance = new GeocodingRequest();
-
-			private static Type S_instanceType;
-			private static MethodInfo _ToUri;
-
-			static GeocodingRequestAccessor()
-			{
-				S_instanceType = typeof(GeocodingRequest);
-
-				try { _ToUri = S_instanceType.GetMethod("ToUri", BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { }, new ParameterModifier[] { }); }
-				catch { }
-				finally { Ensure(_ToUri, "ToUri"); }
-			}
-
-			private static void Ensure(MethodInfo methodInfo, string methodName)
-			{
-				if(methodInfo == null) Assert.Fail("Method '{0}' on type '{1}' was not found, and the accessor will fail.", methodName, S_instanceType);
-			}
-
-			#region Protected/Private interface
-			public Uri ToUri()
-			{
-				try
-				{
-					return (Uri)_ToUri.Invoke(_instance, new object[] { });
-				}
-				catch(TargetInvocationException ex)
-				{
-					throw ex.InnerException;
-				}
-			}
-			#endregion
-
-			#region Public interface copy
-			public Location Address
-			{
-				get { return _instance.Address; }
-				set { this._instance.Address = value; }
-			}
-			public bool? Sensor
-			{
-				get { return this._instance.Sensor; }
-				set { this._instance.Sensor = value; }
-			}
-			#endregion
-
-		}
-
 		//[Test]
 		//[ExpectedException(typeof(InvalidOperationException))]
 		//public void Viewport_has_properties_notset()
@@ -120,7 +68,7 @@ namespace Google.Maps.Test
 		[Test]
 		public void LatLng_for_address_will_invoke_reverse_geocoding()
 		{
-			var req = new GeocodingRequestAccessor();
+			var req = new GeocodingRequest();
 
 			req.Sensor = false;
 			req.Address = new LatLng(-30.1d, 40.2d); //using -30.1f,40.2f gives precision error beyond 6 digits when using format "R". strange.
@@ -135,7 +83,7 @@ namespace Google.Maps.Test
 		[ExpectedException(typeof(InvalidOperationException))]
 		public void GetUrl_sensor_not_set_should_throw_error()
 		{
-			var req = new GeocodingRequestAccessor();
+			var req = new GeocodingRequest();
 			req.Address = "New York, NY";
 
 			var actual = req.ToUri();
@@ -147,7 +95,7 @@ namespace Google.Maps.Test
 		[ExpectedException(typeof(InvalidOperationException))]
 		public void GetUrl_no_Address_set()
 		{
-			var req = new GeocodingRequestAccessor();
+			var req = new GeocodingRequest();
 			//req.Address = something;
 
 			var actual = req.ToUri();

--- a/src/Google.Maps.Test/StaticMaps/StaticMapRequestTests.cs
+++ b/src/Google.Maps.Test/StaticMaps/StaticMapRequestTests.cs
@@ -151,54 +151,34 @@ namespace Google.Maps.Test.StaticMaps
 	[TestFixture]
 	public class StaticMap_Path_Tests
 	{
-		public class StaticMapRequestAccessor
-		{
-			private StaticMapRequest _instance = new StaticMapRequest();
-			private Type _instanceType = typeof(StaticMapRequest);
-
-			public new string GetPathsStr()
-			{
-				MethodInfo method = _instanceType.GetMethod("GetPathsStr", BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { }, new ParameterModifier[] { });
-
-				try
-				{
-					return (string)method.Invoke(_instance, new object[] { });
-				}
-				catch(TargetInvocationException ex)
-				{
-					throw ex.InnerException;
-				}
-			}
-			public Path Path { get { return _instance.Path; } set { this._instance.Path = value; } }
-		}
-
 		[Test]
 		public void Points_One()
 		{
-			StaticMapRequestAccessor accessor = new StaticMapRequestAccessor();
+			var request = new StaticMapRequest { Sensor = true };
 
 			LatLng first = new LatLng(30.1, -60.2);
-			accessor.Path = new Path(first);
+			request.Path = new Path(first);
 
-			string expected = "path=30.1,-60.2";
-			string actual = accessor.GetPathsStr();
+			string expected = "https://maps.google.com/maps/api/staticmap?size=512x512&path=30.1,-60.2&sensor=true";
+			var actual = request.ToUri();
 
-			Assert.AreEqual(expected, actual);
+			Assert.AreEqual(expected, actual.ToString());
 		}
+
 		[Test]
 		public void Points_Two()
 		{
-			StaticMapRequestAccessor accessor = new StaticMapRequestAccessor();
+			var request = new StaticMapRequest { Sensor = true };
 
 			LatLng first = new LatLng(30.1, -60.2);
 			LatLng second = new LatLng(40.3, -70.4);
 
-			accessor.Path = new Path(first, second);
+			request.Path = new Path(first, second);
 
-			string expected = "path=30.1,-60.2%7C40.3,-70.4";
-			string actual = accessor.GetPathsStr();
+			string expected = "https://maps.google.com/maps/api/staticmap?size=512x512&path=30.1,-60.2|40.3,-70.4&sensor=true";
+			var actual = request.ToUri();
 
-			Assert.AreEqual(expected, actual);
+			Assert.AreEqual(expected, actual.ToString());
 		}
 
 		// The color encoding for google static maps API puts the alpha last (0xrrggbbaa)
@@ -221,15 +201,15 @@ namespace Google.Maps.Test.StaticMaps
 		[Test]
 		public void Encoded_SinglePoint()
 		{
-			StaticMapRequestAccessor accessor = new StaticMapRequestAccessor();
+			var request = new StaticMapRequest { Sensor = true };
 
 			LatLng zero = new LatLng(30.0, -60.0);
-			accessor.Path = new Path(zero) { Encode = true };
+			request.Path = new Path(zero) { Encode = true };
 
-			string expected = "path=enc:" + PolylineEncoder.EncodeCoordinates(new LatLng[] { zero });
-			string actual = accessor.GetPathsStr();
+			string expected = "https://maps.google.com/maps/api/staticmap?size=512x512&path=enc:_kbvD~vemJ&sensor=true";
+			var actual = request.ToUri();
 
-			Assert.AreEqual(expected, actual);
+			Assert.AreEqual(expected, actual.ToString());
 		}
 
 		[Test]
@@ -286,14 +266,13 @@ namespace Google.Maps.Test.StaticMaps
 		[ExpectedException(typeof(InvalidOperationException))]
 		public void Encode_set_but_not_all_LatLng_positions()
 		{
-			StaticMapRequestAccessor accessor = new StaticMapRequestAccessor();
+			var request = new StaticMapRequest();
 
 			LatLng first = new LatLng(30.0, -60.0);
 			Location second = new Location("New York");
-			accessor.Path = new Path(first, second) { Encode = true };
+			request.Path = new Path(first, second) { Encode = true };
 
-			string expected = null;//expecting an Exception
-			string actual = accessor.GetPathsStr();
+			var actual = request.ToUri();
 
 			Assert.Fail("Expected an InvalidOperationException because first point was LatLng but second point was Location.");
 		}

--- a/src/Google.Maps/BaseRequest.cs
+++ b/src/Google.Maps/BaseRequest.cs
@@ -7,6 +7,6 @@ namespace Google.Maps
 {
 	public abstract class BaseRequest
 	{
-		internal abstract Uri ToUri();
+		public abstract Uri ToUri();
 	}
 }

--- a/src/Google.Maps/Direction/DirectionRequest.cs
+++ b/src/Google.Maps/Direction/DirectionRequest.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 
 namespace Google.Maps.Direction
 {
-	public class DirectionRequest
+	public class DirectionRequest : BaseRequest
 	{
 		/// <summary>
 		/// The <see cref="Location"/> from which you wish to calculate directions.
@@ -110,7 +110,7 @@ namespace Google.Maps.Direction
 			return sb.ToString();
 		}
 
-		internal Uri ToUri()
+		public override Uri ToUri()
 		{
 			EnsureSensor();
 

--- a/src/Google.Maps/DistanceMatrix/DistanceMatrixRequest.cs
+++ b/src/Google.Maps/DistanceMatrix/DistanceMatrixRequest.cs
@@ -27,7 +27,7 @@ namespace Google.Maps.DistanceMatrix
 	/// <summary>
 	/// Provides a request for the Google Distance Matrix web service.
 	/// </summary>
-	public class DistanceMatrixRequest
+	public class DistanceMatrixRequest : BaseRequest
 	{
 		/// <summary>
 		/// (optional) Specifies what mode of transport to use when calculating directions.
@@ -156,7 +156,7 @@ namespace Google.Maps.DistanceMatrix
 		/// Create URI for quering
 		/// </summary>
 		/// <returns></returns>
-		internal Uri ToUri()
+		public override Uri ToUri()
 		{
 			this.EnsureSensor(true);
 

--- a/src/Google.Maps/Elevation/ElevationRequest.cs
+++ b/src/Google.Maps/Elevation/ElevationRequest.cs
@@ -23,7 +23,7 @@ namespace Google.Maps.Elevation
 	/// <summary>
 	/// Provides a request for the Google Maps Elevation web service.
 	/// </summary>
-	public class ElevationRequest
+	public class ElevationRequest : BaseRequest
 	{
 		/// <summary>
 		/// Defines the location(s) on the earth from which to return elevation
@@ -95,7 +95,7 @@ namespace Google.Maps.Elevation
 		/// <see cref="http://code.google.com/apis/maps/documentation/elevation/#Sensor"/>
 		public bool? Sensor { get; set; }
 
-		internal Uri ToUri()
+		public override Uri ToUri()
 		{
 			this.EnsureSensor(true);
 

--- a/src/Google.Maps/Geocoding/GeocodingRequest.cs
+++ b/src/Google.Maps/Geocoding/GeocodingRequest.cs
@@ -24,7 +24,7 @@ namespace Google.Maps.Geocoding
 	/// <summary>
 	/// Provides a request for the Google Maps Geocoding web service.
 	/// </summary>
-	public class GeocodingRequest
+	public class GeocodingRequest : BaseRequest
 	{
 		/// <summary>
 		/// The address that you want to geocode.  Use LatLng to perform a reverse geocoding request.
@@ -78,7 +78,7 @@ namespace Google.Maps.Geocoding
 		/// <remarks>Required.</remarks>
 		public bool? Sensor { get; set; }
 
-		internal Uri ToUri()
+		public override Uri ToUri()
 		{
 			EnsureSensor();
 

--- a/src/Google.Maps/Places/Autocomplete/AutocompleteRequest.cs
+++ b/src/Google.Maps/Places/Autocomplete/AutocompleteRequest.cs
@@ -61,7 +61,7 @@ namespace Google.Maps.Places
 		/// </summary>
 		public string Components { get; set; }
 
-		internal override Uri ToUri()
+		public override Uri ToUri()
 		{
 			ValidateRequest();
 

--- a/src/Google.Maps/Places/Details/PlaceDetailsRequest.cs
+++ b/src/Google.Maps/Places/Details/PlaceDetailsRequest.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Google.Maps.Places.Details
 {
-	public class PlaceDetailsRequest
+	public class PlaceDetailsRequest : BaseRequest
 	{
 		/// <summary>
 		/// Undocumented address component filters.
@@ -57,7 +57,7 @@ namespace Google.Maps.Places.Details
 		public bool? Sensor { get; set; }
 
 
-		internal Uri ToUri()
+		public override Uri ToUri()
 		{
 			var qsb = new Internal.QueryStringBuilder();
 

--- a/src/Google.Maps/Places/NearbySearchRequest.cs
+++ b/src/Google.Maps/Places/NearbySearchRequest.cs
@@ -69,7 +69,7 @@ namespace Google.Maps.Places
 		/// </summary>
 		public string PageToken { get; set; }
 
-		internal override Uri ToUri()
+		public override Uri ToUri()
 		{
 			ValidateRequest();
 

--- a/src/Google.Maps/Places/RadarSearchRequest.cs
+++ b/src/Google.Maps/Places/RadarSearchRequest.cs
@@ -50,7 +50,7 @@ namespace Google.Maps.Places
 		/// </remarks>
 		public string Name { get; set; }
 
-		internal override Uri ToUri()
+		public override Uri ToUri()
 		{
 			ValidateRequest();
 

--- a/src/Google.Maps/Places/TextSearchRequest.cs
+++ b/src/Google.Maps/Places/TextSearchRequest.cs
@@ -43,7 +43,7 @@ namespace Google.Maps.Places
 		/// </summary>
 		public string PageToken { get; set; }
 
-		internal override Uri ToUri()
+		public override Uri ToUri()
 		{
 			ValidateRequest();
 			var qsb = new Internal.QueryStringBuilder();

--- a/src/Google.Maps/StaticMaps/StaticMapRequest.cs
+++ b/src/Google.Maps/StaticMaps/StaticMapRequest.cs
@@ -33,7 +33,7 @@ namespace Google.Maps.StaticMaps
 	/// the type of map, and the placement of optional markers at locations on
 	/// the map.
 	/// </summary>
-	public class StaticMapRequest
+	public class StaticMapRequest : BaseRequest
 	{
 		public StaticMapRequest()
 		{
@@ -223,7 +223,7 @@ namespace Google.Maps.StaticMaps
 			}
 		}
 
-		public Uri ToUri()
+		public override Uri ToUri()
 		{
 			EnsureSensor(true);
 

--- a/src/Google.Maps/TimeZone/TimeZoneRequest.cs
+++ b/src/Google.Maps/TimeZone/TimeZoneRequest.cs
@@ -22,7 +22,7 @@ namespace Google.Maps.TimeZone
 	/// <summary>
 	/// Provides a request for the Google Maps Time Zone web service.
 	/// </summary>
-	public class TimeZoneRequest
+	public class TimeZoneRequest : BaseRequest
 	{
 		/// <summary>
 		/// The latitude and longitude co-ordinates of the location you want the time zone of.
@@ -55,7 +55,7 @@ namespace Google.Maps.TimeZone
 		/// <see cref="https://developers.google.com/maps/documentation/timezone/intro?hl=en#Sensor"/>
 		public bool? Sensor { get; set; }
 
-		internal Uri ToUri()
+		public override Uri ToUri()
 		{
 			EnsureSensor();
 			if(Location == null) throw new InvalidOperationException("Location property is not set.");


### PR DESCRIPTION
This patch attempts to simplify the code base by making the `ToUri()` method public on all the request classes.

This in turn allows us to delete the "Accessor" classes that were used by tests to gain access to the `ToUri()` method.