### PR TITLE
fix: test using old value for a value returned by Geocoding Service.

### DIFF
--- a/src/Google.Maps.Test/Geocoding/GeocodingServiceTests.cs
+++ b/src/Google.Maps.Test/Geocoding/GeocodingServiceTests.cs
@@ -58,7 +58,7 @@ namespace Google.Maps.Geocoding
 			Assert.AreEqual(1, response.Results.Length);
 
 			var result = response.Results.Single();
-			Assert.AreEqual("Google Bldg 41, 1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA", result.FormattedAddress);
+			Assert.AreEqual("Google Bldg 42, 1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA", result.FormattedAddress);
 			Assert.AreEqual(LocationType.Rooftop, result.Geometry.LocationType);
 
 			var expectedLocation = new LatLng(37.42219410, -122.08459320);


### PR DESCRIPTION
Clearly testing values against a service that might change is not doing us good.

We need to be testing known values via snapshots of responses so that we can guarantee that the serialization routines work correctly.

Different types of tests (integration tests) would then check service response status for values that are present, instead of checking actual values returned... this is a big difference in how we need to be writing tests.