### PR TITLE
change all service ctors in tests to factory methods

### DIFF
--- a/src/Google.Maps.Test/Direction/DirectionServiceTests.cs
+++ b/src/Google.Maps.Test/Direction/DirectionServiceTests.cs
@@ -28,10 +28,18 @@ namespace Google.Maps.Direction
 	[TestFixture]
 	class DirectionServiceTests
 	{
+		GoogleSigned TestingApiKey;
+
+		DirectionService CreateService()
+		{
+			var svc = new DirectionService(TestingApiKey);
+			return svc;
+		}
+
 		[OneTimeSetUp]
 		public void OneTimeSetUp()
 		{
-			GoogleSigned.AssignAllServices(SigningHelper.GetApiKey());
+			TestingApiKey = SigningHelper.GetApiKey();
 		}
 
 		[Test]
@@ -43,7 +51,7 @@ namespace Google.Maps.Direction
 				var request = new DirectionRequest { Origin = "" };
 
 				// Act
-				var response = new DirectionService().GetResponse(request);
+				var response = CreateService().GetResponse(request);
 			});
 		}
 
@@ -58,7 +66,7 @@ namespace Google.Maps.Direction
 			};
 
 			// Act
-			var response = new DirectionService().GetResponse(request);
+			var response = CreateService().GetResponse(request);
 
 			// Assert
 			Assert.AreEqual(ServiceResponseStatus.Ok, response.Status, "Status");

--- a/src/Google.Maps.Test/DistanceMatrix/DistanceMatrixServiceTests.cs
+++ b/src/Google.Maps.Test/DistanceMatrix/DistanceMatrixServiceTests.cs
@@ -8,10 +8,18 @@ namespace Google.Maps.DistanceMatrix
 	[TestFixture]
 	public class DistanceMatrixServiceTests
 	{
+		GoogleSigned TestingApiKey;
+
+		DistanceMatrixService CreateService()
+		{
+			var svc = new DistanceMatrixService(TestingApiKey);
+			return svc;
+		}
+
 		[OneTimeSetUp]
 		public void OneTimeSetUp()
 		{
-			GoogleSigned.AssignAllServices(SigningHelper.GetApiKey());
+			TestingApiKey = SigningHelper.GetApiKey();
 		}
 
 		[Test]
@@ -25,7 +33,7 @@ namespace Google.Maps.DistanceMatrix
 
 			request.Mode = TravelMode.driving;
 
-			DistanceMatrixResponse response = new DistanceMatrixService().GetResponse(request);
+			DistanceMatrixResponse response = CreateService().GetResponse(request);
 
 			Assert.AreEqual(ServiceResponseStatus.Ok, response.Status);
 		}
@@ -41,7 +49,7 @@ namespace Google.Maps.DistanceMatrix
 
 			request.Mode = TravelMode.driving;
 
-			DistanceMatrixResponse response = new DistanceMatrixService().GetResponse(request);
+			DistanceMatrixResponse response = CreateService().GetResponse(request);
 
 			Assert.AreEqual(ServiceResponseStatus.Ok, response.Status);
 		}
@@ -57,7 +65,7 @@ namespace Google.Maps.DistanceMatrix
 
 			request.Mode = TravelMode.driving;
 
-			DistanceMatrixResponse response = new DistanceMatrixService().GetResponse(request);
+			DistanceMatrixResponse response = CreateService().GetResponse(request);
 
 			Assert.AreEqual(ServiceResponseStatus.Ok, response.Status);
 		}
@@ -74,7 +82,7 @@ namespace Google.Maps.DistanceMatrix
 
 			request.Mode = TravelMode.driving;
 
-			DistanceMatrixResponse response = new DistanceMatrixService().GetResponse(request);
+			DistanceMatrixResponse response = CreateService().GetResponse(request);
 
 			Assert.AreEqual(ServiceResponseStatus.Ok, response.Status);
 			Assert.AreEqual(1, response.DestinationAddresses.Length);
@@ -93,7 +101,7 @@ namespace Google.Maps.DistanceMatrix
 
 			request.Mode = TravelMode.driving;
 
-			DistanceMatrixResponse response = new DistanceMatrixService().GetResponse(request);
+			DistanceMatrixResponse response = CreateService().GetResponse(request);
 
 			Assert.AreEqual(ServiceResponseStatus.Ok, response.Status);
 			Assert.AreEqual(1, response.DestinationAddresses.Length);
@@ -115,7 +123,7 @@ namespace Google.Maps.DistanceMatrix
 
 			request.Mode = TravelMode.driving;
 
-			DistanceMatrixResponse response = new DistanceMatrixService().GetResponse(request);
+			DistanceMatrixResponse response = CreateService().GetResponse(request);
 
 			Assert.AreEqual(ServiceResponseStatus.Ok, response.Status);
 			Assert.Greater(response.DestinationAddresses.Length, 1);
@@ -135,7 +143,7 @@ namespace Google.Maps.DistanceMatrix
 
 			request.Mode = TravelMode.driving;
 
-			DistanceMatrixResponse response = new DistanceMatrixService().GetResponse(request);
+			DistanceMatrixResponse response = CreateService().GetResponse(request);
 
 			Assert.AreEqual(ServiceResponseStatus.Ok, response.Status);
 			Assert.Greater(response.DestinationAddresses.Length, 1);

--- a/src/Google.Maps.Test/Elevation/ElevationServiceTests.cs
+++ b/src/Google.Maps.Test/Elevation/ElevationServiceTests.cs
@@ -24,10 +24,18 @@ namespace Google.Maps.Elevation
 	[TestFixture]
 	public class ElevationServiceTests
 	{
+		GoogleSigned TestingApiKey;
+
+		ElevationService CreateService()
+		{
+			var svc = new ElevationService(TestingApiKey);
+			return svc;
+		}
+
 		[OneTimeSetUp]
 		public void OneTimeSetUp()
 		{
-			GoogleSigned.AssignAllServices(SigningHelper.GetApiKey());
+			TestingApiKey = SigningHelper.GetApiKey();
 		}
 
 		[Test]
@@ -43,7 +51,7 @@ namespace Google.Maps.Elevation
 			var request = new ElevationRequest();
 
 			request.AddLocations(expectedLocation);
-			var response = new ElevationService().GetResponse(request);
+			var response = CreateService().GetResponse(request);
 
 			// asserts
 			Assert.AreEqual(expectedStatus, response.Status);
@@ -70,7 +78,7 @@ namespace Google.Maps.Elevation
 			var request = new ElevationRequest();
 
 			request.AddLocations(expectedLocation1, expectedLocation2);
-			var response = new ElevationService().GetResponse(request);
+			var response = CreateService().GetResponse(request);
 
 			// asserts
 			Assert.AreEqual(expectedStatus, response.Status);

--- a/src/Google.Maps.Test/Geocoding/GeocodingServiceTests.cs
+++ b/src/Google.Maps.Test/Geocoding/GeocodingServiceTests.cs
@@ -28,10 +28,18 @@ namespace Google.Maps.Geocoding
 	[TestFixture]
 	class GeocodingServiceTests
 	{
+		GoogleSigned TestingApiKey;
+
+		GeocodingService CreateService()
+		{
+			var svc = new GeocodingService(TestingApiKey);
+			return svc;
+		}
+
 		[OneTimeSetUp]
 		public void OneTimeSetUp()
 		{
-			GoogleSigned.AssignAllServices(SigningHelper.GetApiKey());
+			TestingApiKey = SigningHelper.GetApiKey();
 		}
 
 		[Test]
@@ -40,7 +48,7 @@ namespace Google.Maps.Geocoding
 			Assert.Throws<HttpRequestException>(() =>
 			{
 				var request = new GeocodingRequest { Address = "" };
-				var response = new GeocodingService().GetResponse(request);
+				var response = CreateService().GetResponse(request);
 			});
 		}
 
@@ -51,7 +59,7 @@ namespace Google.Maps.Geocoding
 			var request = new GeocodingRequest { Address = "1600 Amphitheatre Parkway Mountain View CA" };
 
 			// Act
-			var response = new GeocodingService().GetResponse(request);
+			var response = CreateService().GetResponse(request);
 
 			// Assert
 			Assert.AreEqual(ServiceResponseStatus.Ok, response.Status);
@@ -78,7 +86,7 @@ namespace Google.Maps.Geocoding
 			// test
 			var request = new GeocodingRequest();
 			request.Address = "11 Wall Street New York NY 10005";
-			var actual = new GeocodingService().GetResponse(request);
+			var actual = CreateService().GetResponse(request);
 
 			// asserts
 			Assert.AreEqual(ServiceResponseStatus.Ok, actual.Status);
@@ -104,8 +112,8 @@ namespace Google.Maps.Geocoding
 				Components = "country:US"
 			};
 
-			var responseGB = new GeocodingService().GetResponse(requestGB);
-			var responseUS = new GeocodingService().GetResponse(requestUS);
+			var responseGB = CreateService().GetResponse(requestGB);
+			var responseUS = CreateService().GetResponse(requestUS);
 
 			Assert.AreEqual(ServiceResponseStatus.Ok, responseGB.Status);
 			Assert.AreEqual(ServiceResponseStatus.Ok, responseUS.Status);
@@ -129,7 +137,7 @@ namespace Google.Maps.Geocoding
 				Address = "Boston"
 			};
 
-			var response = new GeocodingService().GetResponse(request);
+			var response = CreateService().GetResponse(request);
 
 			foreach (var r in response.Results)
 			{
@@ -145,7 +153,7 @@ namespace Google.Maps.Geocoding
 				Address = "Boston"
 			};
 
-			var response = new GeocodingService().GetResponse(request);
+			var response = CreateService().GetResponse(request);
 
 			Assert.AreEqual(ServiceResponseStatus.Ok, response.Status);
 			Assert.IsNotNull(response.Results[0].Geometry.Bounds);
@@ -161,7 +169,7 @@ namespace Google.Maps.Geocoding
 				Address = "Stathern, UK"
 			};
 
-			var response = new GeocodingService().GetResponse(request);
+			var response = CreateService().GetResponse(request);
 
 			var postalTown = response.Results[0].AddressComponents.First(x => x.ShortName == "Melton Mowbray");
 			Assert.IsFalse(postalTown.Types.Contains(AddressType.Unknown), postalTown.ShortName + " should be AddressType PostalTown");

--- a/src/Google.Maps.Test/TimeZone/TimeZoneServiceTests.cs
+++ b/src/Google.Maps.Test/TimeZone/TimeZoneServiceTests.cs
@@ -24,10 +24,18 @@ namespace Google.Maps.TimeZone
 {
 	public class TimeZoneServiceTests
 	{
+		GoogleSigned TestingApiKey;
+
+		TimeZoneService CreateService()
+		{
+			var svc = new TimeZoneService(TestingApiKey);
+			return svc;
+		}
+
 		[OneTimeSetUp]
 		public void OneTimeSetUp()
 		{
-			GoogleSigned.AssignAllServices(SigningHelper.GetApiKey());
+			TestingApiKey = SigningHelper.GetApiKey();
 		}
 
 		[Test]
@@ -41,7 +49,7 @@ namespace Google.Maps.TimeZone
 			};
 
 			// Act
-			var response = new TimeZoneService().GetResponse(request);
+			var response = CreateService().GetResponse(request);
 
 			// Assert
 			Assert.AreEqual(ServiceResponseStatus.Ok, response.Status);
@@ -61,7 +69,7 @@ namespace Google.Maps.TimeZone
 			};
 
 			// Act
-			var response = new TimeZoneService().GetResponse(request);
+			var response = CreateService().GetResponse(request);
 
 			// Assert
 			Assert.AreEqual(ServiceResponseStatus.Ok, response.Status);


### PR DESCRIPTION
We need to do some dependency injection at some point.

This pull request makes all tests use a factory method to create the service, which gives us a decoupling of the service creation from usage within the tests.