### PR TITLE
Fix V3025

### DIFF
--- a/src/Google.Maps/StaticMaps/StaticMapRequest.cs
+++ b/src/Google.Maps/StaticMaps/StaticMapRequest.cs
@@ -66,7 +66,7 @@ namespace Google.Maps.StaticMaps
 			{
 				if(value != null)
 				{
-					if(value < Constants.ZOOM_LEVEL_MIN) throw new ArgumentOutOfRangeException(string.Format("value cannot be less than 0.", Constants.ZOOM_LEVEL_MIN));
+					if(value < Constants.ZOOM_LEVEL_MIN) throw new ArgumentOutOfRangeException(string.Format("value cannot be less than {0}.", Constants.ZOOM_LEVEL_MIN));
 				}
 				_zoom = value;
 			}


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- Incorrect format. A different number of format items is expected while calling 'Format' function. Arguments not used: Constants.ZOOM_LEVEL_MIN. Google.Maps StaticMapRequest.cs 69