### PR TITLE
#130 adds PlaceId as option for GeocodingRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Google Maps API for .NET
 
 [![AppVeyor](https://img.shields.io/appveyor/ci/EricNewton/gmaps-api-net.svg)](https://ci.appveyor.com/project/EricNewton/gmaps-api-net)
+[![Nuget](https://img.shields.io/nuget/v/gmaps-api-net.svg)](https://www.nuget.org/packages/gmaps-api-net/)
 [![Join the chat at https://gitter.im/gmaps-api-net/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/gmaps-api-net/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 A .NET library for interacting with the Google Maps API suite.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ PS> Install-Package gmaps-api-net
 ## Overview
 This project attempts to provide all the features available in the Google Maps API. It is being developed in C# for the Microsoft .NET including .Net Framework v4.6.1+ and .Net Standard v1.3+. *gmaps-api-net* is a fully featured API client library, providing strongly typed access to the API.
 
+## Notable Upcoming 
+* Trying to achieve a formal v1.0 release for 2018. This is basically on-track for first week of January. File any major issues quickly to get addressed before v1.0!
+* Planning a slight namespace/usage change for v2.0 release soon thereafter to support dependency injection and mocking away the library in your own testing apparatus.  Intention here is to isolate away the library returning values to returning known values during your testing. See branch [feat/support-dependency-injection](https://github.com/ericnewton76/gmaps-api-net/tree/feat/support-dependency-injection)
+* In relation to above, we will begin removing our tests for specific values, and testing instead for schema changes that Google is pushing through.
+
 ## API Support
 
 Currently the library supports full coverage of the following Google Maps APIs:
@@ -24,12 +29,6 @@ Currently the library supports full coverage of the following Google Maps APIs:
   * Places
   * Time Zones
   * Street View, added to v0.19
-
-## Notable Upcoming 
-
-* Trying to achieve a formal v1.0 release for 2018. This is basically on-track for first week of January. File any major issues quickly to get addressed before v1.0!
-* Planning a slight namespace/usage change for v2.0 release soon thereafter to support dependency injection and mocking away the library in your own testing apparatus.  Intention here is to isolate away the library returning values to returning known values during your testing.
-* In relation to above, we will begin removing our tests for specific values, and testing instead for schema changes that Google is pushing through.
 
 ## Quick Examples
 Using Google Maps API for .NET is designed to be really easy.

--- a/src/Google.Maps.Test/Geocoding/GeocodingRequestTests.cs
+++ b/src/Google.Maps.Test/Geocoding/GeocodingRequestTests.cs
@@ -78,6 +78,20 @@ namespace Google.Maps.Geocoding
 		}
 
 		[Test]
+		[Category("ValueTesting")]
+		public void Implicit_PlaceId_set_from_string()
+		{
+			var req = new GeocodingRequest();
+
+			req.PlaceId = "ChIJN1t_tDeuEmsRUsoyG83frY4"; // Google
+
+			Uri expected = new Uri("json?place_id=ChIJN1t_tDeuEmsRUsoyG83frY4", UriKind.Relative);
+			Uri actual = req.ToUri();
+
+			Assert.AreEqual(expected, actual);
+		}
+
+		[Test]
 		public void GetUrl_no_Address_set()
 		{
 			Assert.Throws<InvalidOperationException>(() =>

--- a/src/Google.Maps/Geocoding/GeocodingRequest.cs
+++ b/src/Google.Maps/Geocoding/GeocodingRequest.cs
@@ -34,6 +34,14 @@ namespace Google.Maps.Geocoding
 		public Location Address { get; set; }
 
 		/// <summary>
+		/// The place ID of the place for which you wish to obtain the human-readable address. The
+		/// place ID is a unique identifier that can be used from/with other Google APIs (Roads API,
+		/// Places API).
+		/// <see href="https://developers.google.com/maps/documentation/geocoding/intro#place-id"/>
+		/// </summary>
+		public string PlaceId { get; set; }
+
+		/// <summary>
 		/// Undocumented address component filters.
 		/// Only geocoding results matching the component filters will be returned.
 		/// </summary>
@@ -73,7 +81,7 @@ namespace Google.Maps.Geocoding
 
 		public override Uri ToUri()
 		{
-			if (Address == null) throw new InvalidOperationException("Address is required");
+			if (Address == null && String.IsNullOrWhiteSpace(PlaceId)) throw new InvalidOperationException("Address/LatLng or PlaceId is required");
 
 			var qsb = new Internal.QueryStringBuilder();
 
@@ -87,6 +95,10 @@ namespace Google.Maps.Geocoding
 				{
 					qsb.Append("address", Address.GetAsUrlParameter());
 				}
+			}
+			else
+			{
+				qsb.Append("place_id", PlaceId);
 			}
 
 			qsb.Append("bounds", GetBoundsStr())


### PR DESCRIPTION
Here's an attempt at a solution for #130 

I thought about making a Place object that inherits Location, so that it could just be assigned to GeocodeRequest.Address (just like LatLng), but assigning LatLng to Address was a little confusing for me. Knowing the request has an "address" parameter and a "latlng" parameter, I saw the Address property and was looking for a LatLng property on GeocodeRequest.

Let me know if you want to do anything more/different.