### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ this.imageControl.Image = img;
 
 ```c#
 //enterprise users to use your supplied information for requests.  Do this in App_Start.
-GoogleSigned.AssignAllServices(new GoogleSigned("gme-your-client-id", "your-signing-key"));
+GoogleSigned.AssignAllServices(new GoogleSigned("gme-your-client-id", "your-signing-key", signType: GoogleSignedType.Business));
 
 // Then do as many requests as you like...
 var request = new GeocodingRequest();


### PR DESCRIPTION
For enterprise calls, need to specify signType of GoogleSignedType.Business, otherwise the requests are sent as regular API key calls and fail.