### PR TITLE
Add support for DurationInTraffic

### DIFF
--- a/src/Google.Maps/AvoidHelper.cs
+++ b/src/Google.Maps/AvoidHelper.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace Google.Maps

--- a/src/Google.Maps/BaseRequest.cs
+++ b/src/Google.Maps/BaseRequest.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Google.Maps
 {

--- a/src/Google.Maps/Common/IServiceResponse.cs
+++ b/src/Google.Maps/Common/IServiceResponse.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Google.Maps.Common
+﻿namespace Google.Maps.Common
 {
     public interface IServiceResponse
     {

--- a/src/Google.Maps/ComponentFilter.cs
+++ b/src/Google.Maps/ComponentFilter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Google.Maps
 {

--- a/src/Google.Maps/Constants.cs
+++ b/src/Google.Maps/Constants.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace Google.Maps

--- a/src/Google.Maps/Direction/DirectionLeg.cs
+++ b/src/Google.Maps/Direction/DirectionLeg.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Google.Maps.Direction
 {

--- a/src/Google.Maps/Direction/DirectionLeg.cs
+++ b/src/Google.Maps/Direction/DirectionLeg.cs
@@ -15,7 +15,7 @@ namespace Google.Maps.Direction
 		public ValueText Duration { get; set; }
 		
 		[JsonProperty("duration_in_traffic")]
-		public ValueText Duration { get; set; }
+		public ValueText DurationInTraffic { get; set; }
 
 		[JsonProperty("distance")]
 		public ValueText Distance { get; set; }

--- a/src/Google.Maps/Direction/DirectionLeg.cs
+++ b/src/Google.Maps/Direction/DirectionLeg.cs
@@ -13,6 +13,9 @@ namespace Google.Maps.Direction
 
 		[JsonProperty("duration")]
 		public ValueText Duration { get; set; }
+		
+		[JsonProperty("duration_in_traffic")]
+		public ValueText Duration { get; set; }
 
 		[JsonProperty("distance")]
 		public ValueText Distance { get; set; }

--- a/src/Google.Maps/Direction/DirectionRequest.cs
+++ b/src/Google.Maps/Direction/DirectionRequest.cs
@@ -24,6 +24,15 @@ namespace Google.Maps.Direction
 		[DefaultValue(TravelMode.driving)]
 		public TravelMode Mode { get; set; }
 
+
+		/// <summary>
+		/// Specifies the assumptions to use when calculating time in traffic. This setting affects the value returned in the duration_in_traffic field in the response,
+		/// which contains the predicted time in traffic based on historical averages. The traffic_model parameter may only be specified for driving directions where
+		/// the request includes a departure_time, and only if the request includes an API key or a Google Maps Platform Premium Plan client ID. 
+		/// </summary>
+		[DefaultValue(TrafficModel.best_guess)]
+		public TrafficModel TrafficModel { get; set; }
+
 		/// <summary>
 		/// (optional) Directions may be calculated that adhere to certain restrictions.
 		/// </summary>
@@ -119,6 +128,7 @@ namespace Google.Maps.Direction
 				.Append("origin", (Origin == null ? (string)null : Origin.GetAsUrlParameter()))
 				.Append("destination", (Destination == null ? (string)null : Destination.GetAsUrlParameter()))
 				.Append("mode", (Mode != TravelMode.driving ? Mode.ToString() : (string)null))
+				.Append("traffic_model", (TrafficModel!=TrafficModel.best_guess ? TrafficModel.ToString():(string)null))
 				.Append("departure_time", (DepartureTime == null ? null : DepartureTime.Value.ToString()))
 				.Append("arrival_time", (ArrivalTime == null ? null : ArrivalTime.Value.ToString()))
 				.Append("waypoints", WaypointsToUri())

--- a/src/Google.Maps/Direction/DirectionRequest.cs
+++ b/src/Google.Maps/Direction/DirectionRequest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using Google.Maps;
 using System.ComponentModel;
 
 namespace Google.Maps.Direction

--- a/src/Google.Maps/Direction/DirectionResponse.cs
+++ b/src/Google.Maps/Direction/DirectionResponse.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Google.Maps.Common;
 
 namespace Google.Maps.Direction

--- a/src/Google.Maps/Direction/DirectionRoute.cs
+++ b/src/Google.Maps/Direction/DirectionRoute.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Google.Maps.Direction
 {

--- a/src/Google.Maps/Direction/DirectionStep.cs
+++ b/src/Google.Maps/Direction/DirectionStep.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Newtonsoft.Json;
 
 namespace Google.Maps.Direction
@@ -22,6 +20,9 @@ namespace Google.Maps.Direction
 
 		[JsonProperty("duration")]
 		public ValueText Duration { get; set; }
+
+		[JsonProperty("duration_in_traffic")]
+		public ValueText DurationInTraffic { get; set; }
 
 		[Obsolete("maneuver is obsolete", false)]
 		public string Maneuver { get; set; }

--- a/src/Google.Maps/Direction/DirectionTransitDetails.cs
+++ b/src/Google.Maps/Direction/DirectionTransitDetails.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Google.Maps.Direction
 {

--- a/src/Google.Maps/Direction/GeocodedWaypoint.cs
+++ b/src/Google.Maps/Direction/GeocodedWaypoint.cs
@@ -1,9 +1,5 @@
 ﻿using Google.Maps.Shared;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Google.Maps.Direction
 {

--- a/src/Google.Maps/Direction/LineInfo.cs
+++ b/src/Google.Maps/Direction/LineInfo.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 
 namespace Google.Maps.Direction

--- a/src/Google.Maps/Direction/Polyline.cs
+++ b/src/Google.Maps/Direction/Polyline.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Google.Maps.Direction
 {

--- a/src/Google.Maps/Direction/Stop.cs
+++ b/src/Google.Maps/Direction/Stop.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Google.Maps.Direction
 {

--- a/src/Google.Maps/Direction/Time.cs
+++ b/src/Google.Maps/Direction/Time.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Google.Maps.Direction
 {

--- a/src/Google.Maps/Direction/TransitAgency .cs
+++ b/src/Google.Maps/Direction/TransitAgency .cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 
 namespace Google.Maps.Direction

--- a/src/Google.Maps/Direction/VehicleInfo.cs
+++ b/src/Google.Maps/Direction/VehicleInfo.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Google.Maps.Direction
 {

--- a/src/Google.Maps/DistanceMatrix/DistanceMatrixRequest.cs
+++ b/src/Google.Maps/DistanceMatrix/DistanceMatrixRequest.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using Google.Maps;
 using System.Text;
 using System.Linq;
 

--- a/src/Google.Maps/DistanceMatrix/DistanceMatrixResponse.cs
+++ b/src/Google.Maps/DistanceMatrix/DistanceMatrixResponse.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Google.Maps.Common;
 
 namespace Google.Maps.DistanceMatrix

--- a/src/Google.Maps/ExceptionHelper.cs
+++ b/src/Google.Maps/ExceptionHelper.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Google.Maps
 {

--- a/src/Google.Maps/GMapsImageFormats.cs
+++ b/src/Google.Maps/GMapsImageFormats.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Google.Maps
+﻿namespace Google.Maps
 {
 	/// <summary>
 	/// Represents the different image formats available from the Google Maps API.

--- a/src/Google.Maps/Geocoding/GeocodeResponse.cs
+++ b/src/Google.Maps/Geocoding/GeocodeResponse.cs
@@ -17,7 +17,6 @@
 
 using Google.Maps.Common;
 using Newtonsoft.Json;
-using System;
 
 namespace Google.Maps.Geocoding
 {

--- a/src/Google.Maps/Geocoding/Result.cs
+++ b/src/Google.Maps/Geocoding/Result.cs
@@ -16,7 +16,6 @@
  */
 
 using Newtonsoft.Json;
-using System;
 using Google.Maps.Shared;
 
 namespace Google.Maps.Geocoding

--- a/src/Google.Maps/Google.Maps.csproj
+++ b/src/Google.Maps/Google.Maps.csproj
@@ -10,7 +10,7 @@
     <DefineConstants>HAS_SYSTEMDRAWING</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Net.Http" />

--- a/src/Google.Maps/Google.Maps.csproj
+++ b/src/Google.Maps/Google.Maps.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
@@ -11,8 +11,5 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 </Project>

--- a/src/Google.Maps/Google.Maps.csproj
+++ b/src/Google.Maps/Google.Maps.csproj
@@ -1,10 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+	  <TargetFramework>net7.0</TargetFramework>
+	  <LangVersion>latest</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <DelaySign>False</DelaySign>
+    <Configurations>Debug;Release;Release_PathDiagnostics</Configurations>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net461'">
     <DefineConstants>HAS_SYSTEMDRAWING</DefineConstants>

--- a/src/Google.Maps/Internal/ConvertUtil.cs
+++ b/src/Google.Maps/Internal/ConvertUtil.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Collections.Generic;
-using System.Text;
 using System.Collections;
 
 namespace Google.Maps.Internal

--- a/src/Google.Maps/Internal/QueryStringBuilder.cs
+++ b/src/Google.Maps/Internal/QueryStringBuilder.cs
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-using System;
-
 namespace Google.Maps.Internal
 {
 	internal class QueryStringBuilder

--- a/src/Google.Maps/Internal/RequestUtils.cs
+++ b/src/Google.Maps/Internal/RequestUtils.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 

--- a/src/Google.Maps/Internal/StringCaseExtensions.cs
+++ b/src/Google.Maps/Internal/StringCaseExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
 
 namespace Google.Maps.Internal
 {

--- a/src/Google.Maps/Internal/ValueTextComparer.cs
+++ b/src/Google.Maps/Internal/ValueTextComparer.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Google.Maps
 {

--- a/src/Google.Maps/JsonEnumTypeConverter.cs
+++ b/src/Google.Maps/JsonEnumTypeConverter.cs
@@ -16,7 +16,6 @@
  */
 
 using System;
-using Google.Maps.Geocoding;
 using Google.Maps.Shared;
 using Newtonsoft.Json;
 

--- a/src/Google.Maps/LatLngComparer.cs
+++ b/src/Google.Maps/LatLngComparer.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Google.Maps
 {

--- a/src/Google.Maps/Location.cs
+++ b/src/Google.Maps/Location.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Google.Maps
+﻿namespace Google.Maps
 {
 	/// <summary>
 	/// A general free-text location, usually for specifying an address or particular place for Google Maps.

--- a/src/Google.Maps/MapMarker.cs
+++ b/src/Google.Maps/MapMarker.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace Google.Maps

--- a/src/Google.Maps/MapMarkersCollection.cs
+++ b/src/Google.Maps/MapMarkersCollection.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace Google.Maps
 {

--- a/src/Google.Maps/MapTypes.cs
+++ b/src/Google.Maps/MapTypes.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Google.Maps
+﻿namespace Google.Maps
 {
 	/// <summary>
 	/// The available map types for the current Google Maps API.

--- a/src/Google.Maps/MarkerSizes.cs
+++ b/src/Google.Maps/MarkerSizes.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Google.Maps
+﻿namespace Google.Maps
 {
 	/// <summary>
 	/// The set of marker sizes available for the current Google Maps API.

--- a/src/Google.Maps/Path.cs
+++ b/src/Google.Maps/Path.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace Google.Maps

--- a/src/Google.Maps/Places/Autocomplete/AutocompleteRequest.cs
+++ b/src/Google.Maps/Places/Autocomplete/AutocompleteRequest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Google.Maps.Internal;
 
 namespace Google.Maps.Places

--- a/src/Google.Maps/Places/Autocomplete/AutocompleteResponse.cs
+++ b/src/Google.Maps/Places/Autocomplete/AutocompleteResponse.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Google.Maps.Places
 {

--- a/src/Google.Maps/Places/Autocomplete/AutocompleteResult.cs
+++ b/src/Google.Maps/Places/Autocomplete/AutocompleteResult.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Google.Maps.Places
 {

--- a/src/Google.Maps/Places/Details/PlaceDetailsRequest.cs
+++ b/src/Google.Maps/Places/Details/PlaceDetailsRequest.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace Google.Maps.Places.Details
 {

--- a/src/Google.Maps/Places/Details/PlaceDetailsResponse.cs
+++ b/src/Google.Maps/Places/Details/PlaceDetailsResponse.cs
@@ -1,8 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Google.Maps.Places.Details
 {

--- a/src/Google.Maps/Places/Details/Scope.cs
+++ b/src/Google.Maps/Places/Details/Scope.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Google.Maps.Places.Details
+﻿namespace Google.Maps.Places.Details
 {
 	public enum Scope
 	{

--- a/src/Google.Maps/Places/PlacesResult.cs
+++ b/src/Google.Maps/Places/PlacesResult.cs
@@ -17,7 +17,6 @@
 
 using Google.Maps.Shared;
 using Newtonsoft.Json;
-using System;
 
 namespace Google.Maps.Places
 {

--- a/src/Google.Maps/Properties/AssemblyInfo.cs
+++ b/src/Google.Maps/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/src/Google.Maps/RankBy.cs
+++ b/src/Google.Maps/RankBy.cs
@@ -15,12 +15,6 @@
  * limitations under the License.
  */
 
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 namespace Google.Maps
 {
 	public enum RankBy

--- a/src/Google.Maps/Shared/Geometry.cs
+++ b/src/Google.Maps/Shared/Geometry.cs
@@ -16,7 +16,6 @@
  */
 
 using Newtonsoft.Json;
-using System;
 
 namespace Google.Maps.Shared
 {

--- a/src/Google.Maps/Shared/Viewport.cs
+++ b/src/Google.Maps/Shared/Viewport.cs
@@ -16,7 +16,6 @@
  */
 
 using Newtonsoft.Json;
-using System;
 
 namespace Google.Maps.Shared
 {

--- a/src/Google.Maps/StreetView/StreetViewRequest.cs
+++ b/src/Google.Maps/StreetView/StreetViewRequest.cs
@@ -16,9 +16,6 @@
  */
 
 using System;
-using System.Linq;
-using System.Collections.Generic;
-
 using Google.Maps.Internal;
 using System.ComponentModel;
 

--- a/src/Google.Maps/TimeZone/TimeZoneResponse.cs
+++ b/src/Google.Maps/TimeZone/TimeZoneResponse.cs
@@ -16,7 +16,6 @@
  */
 
 using Newtonsoft.Json;
-using System;
 using Google.Maps.Common;
 
 namespace Google.Maps.TimeZone

--- a/src/Google.Maps/TrafficModel.cs
+++ b/src/Google.Maps/TrafficModel.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Google.Maps {
+	/// <summary>
+	/// Specifies the assumptions to use when calculating time in traffic. This setting affects the value returned in the duration_in_traffic field in the response,
+	/// which contains the predicted time in traffic based on historical averages. The traffic_model parameter may only be specified for driving directions where
+	/// the request includes a departure_time, and only if the request includes an API key or a Google Maps Platform Premium Plan client ID. 
+	/// </summary>
+	/// <see href="http://code.google.com/apis/maps/documentation/directions/#traffic_model"/>
+	public enum TrafficModel {
+		/// <summary>
+		/// (default) indicates that the returned duration_in_traffic should be the best estimate of travel time given what is known about both historical
+		/// traffic conditions and live traffic. Live traffic becomes more important the closer the departure_time is to now.
+		/// </summary>
+		best_guess,
+
+		/// <summary>
+		///  indicates that the returned duration_in_traffic should be longer than the actual travel time on most days, though occasional days with particularly bad traffic conditions may exceed this value
+		/// </summary>
+		pessimistic,
+
+		/// <summary>
+		/// indicates that the returned duration_in_traffic should be shorter than the actual travel time on most days, though occasional days with particularly good traffic conditions may be faster than this value.
+		/// </summary>
+		optimistic,
+
+	}
+}

--- a/src/Google.Maps/TrafficModel.cs
+++ b/src/Google.Maps/TrafficModel.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Google.Maps {
+﻿namespace Google.Maps {
 	/// <summary>
 	/// Specifies the assumptions to use when calculating time in traffic. This setting affects the value returned in the duration_in_traffic field in the response,
 	/// which contains the predicted time in traffic based on historical averages. The traffic_model parameter may only be specified for driving directions where

--- a/src/Google.Maps/TravelMode.cs
+++ b/src/Google.Maps/TravelMode.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Google.Maps
+﻿namespace Google.Maps
 {
 	/// <summary>
 	/// When you calculate directions, you may specify which transportation mode to use. By default, directions are calculated as driving directions. The following travel modes are currently supported:

--- a/src/Google.Maps/Units.cs
+++ b/src/Google.Maps/Units.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Google.Maps
+﻿namespace Google.Maps
 {
 	/// <summary>
 	///  When you calculate Directions Matrix, you may specify which Unit system mode to use. 

--- a/src/Google.Maps/ValueText.cs
+++ b/src/Google.Maps/ValueText.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Newtonsoft.Json;
 
 namespace Google.Maps


### PR DESCRIPTION
If the DepartureTime is set then Google can return congested travel times. This adds support for obtaining the new output, as well as an extra setting in the request to specify the traffic model to use. 
I also updated the Newtonsoft.Json to the latest version.